### PR TITLE
Fix: Github Workflows with Python 3.14

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,6 +59,9 @@ jobs:
       - name: Install test dependencies.
         run: pip3 install ansible-core>=2.20.0 molecule molecule-plugins[docker]
 
+      - name: Install role dependencies.
+        run: ansible-galaxy collection install community.general
+
       - name: Run Molecule tests.
         run: molecule test --all
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,13 +18,13 @@ jobs:
       - name: Check out the codebase.
         uses: actions/checkout@v4
 
-      - name: Set up Python 3.x
+      - name: Set up Python 3
         uses: actions/setup-python@v5
         with:
-          python-version: '3.x'
+          python-version: '3.14'
 
       - name: Install test dependencies.
-        run: pip3 install yamllint ansible-lint ansible
+        run: pip3 install yamllint ansible-lint ansible-core>=2.20.0
 
       - name: Run yamllint.
         run: yamllint .
@@ -54,10 +54,10 @@ jobs:
       - name: Set up Python 3.
         uses: actions/setup-python@v5
         with:
-          python-version: '3.x'
+          python-version: '3.14'
 
       - name: Install test dependencies.
-        run: pip3 install ansible molecule molecule-plugins[docker]
+        run: pip3 install ansible-core>=2.20.0 molecule molecule-plugins[docker]
 
       - name: Run Molecule tests.
         run: molecule test --all

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,13 +13,13 @@ jobs:
       - name: Check out the codebase.
         uses: actions/checkout@v4
 
-      - name: Set up Python 3.x
+      - name: Set up Python 3.
         uses: actions/setup-python@v5
         with:
-          python-version: '3.x'
+          python-version: '3.14'
 
       - name: Install test dependencies.
-        run: pip3 install yamllint ansible-lint ansible
+        run: pip3 install yamllint ansible-lint ansible-core>=2.20.0
 
       - name: Run yamllint.
         run: yamllint .
@@ -49,10 +49,10 @@ jobs:
       - name: Set up Python 3.
         uses: actions/setup-python@v5
         with:
-          python-version: '3.x'
+          python-version: '3.14'
 
       - name: Install test dependencies.
-        run: pip3 install ansible molecule molecule-plugins[docker]
+        run: pip3 install ansible-core>=2.20.0 molecule molecule-plugins[docker]
 
       - name: Run Molecule tests.
         run: molecule test --all


### PR DESCRIPTION
- Explicitly require Python 3.14 for Github Runners
- Install `ansible-core` version >= 2.20.0 as required by Python 3.14 to Github Runners
